### PR TITLE
This exception is unused and inherits from Exception rather than HttpException

### DIFF
--- a/bigcommerce/exception.py
+++ b/bigcommerce/exception.py
@@ -37,5 +37,3 @@ class ServerException(HttpException): pass
 
 # 3xx codes
 class RedirectionException(HttpException): pass
-
-class NotLoggedInException(Exception): pass


### PR DESCRIPTION
From the root of the repo:

    ➤ grep NotLoggedInException . -R -n
    ./bigcommerce/exception.py:41:class NotLoggedInException(Exception): pass

Is there a usecase for it that I am missing?