### PR TITLE
Allow override of API endpoint with environment var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
+  - "3.4"
 script: nosetests -a '!broken'

--- a/bigcommerce/api.py
+++ b/bigcommerce/api.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from bigcommerce import connection
 from bigcommerce.resources import * # Needed for ApiResourceWrapper dynamic loading
@@ -9,9 +10,10 @@ class BigcommerceApi(object):
         if host and basic_auth:
             self.connection = connection.Connection(host, basic_auth)
         elif client_id and store_hash:
-            self.connection = connection.OAuthConnection(client_id, store_hash, access_token)
+            api_host = os.getenv('BC_API_ENDPOINT', 'api.bigcommerce.com')
+            self.connection = connection.OAuthConnection(client_id, store_hash, access_token, host=api_host)
         else:
-            raise Exception("Must provide either (client_id and store_hash) or (store_endpoint and basic_auth)")
+            raise Exception("Must provide either (client_id and store_hash) or (host and basic_auth)")
 
     def oauth_fetch_token(self, client_secret, code, context, scope, redirect_uri):
         if isinstance(self.connection, connection.OAuthConnection):

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -11,10 +11,10 @@ try:
     from urllib import urlencode
 except ImportError:
     from urllib.parse import urlencode
+
 import json  # only used for urlencode querystr
 import logging
 import streql
-
 import requests
 
 from bigcommerce.exception import *
@@ -173,14 +173,11 @@ class OAuthConnection(Connection):
     The verify_payload method is also provided for authenticating signed payloads passed to an application's load url.
     """
 
-    def __init__(self, client_id, store_hash, access_token=None,
-                 host='api.bigcommerce.com', api_path='/stores/{}/v2/{}'):
+    def __init__(self, client_id, store_hash, access_token=None, host='api.bigcommerce.com', api_path='/stores/{}/v2/{}'):
         self.client_id = client_id
         self.store_hash = store_hash
-
         self.host = host
         self.api_path = api_path
-
         self.timeout = 7.0  # can attach to session?
 
         self._session = requests.Session()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import bigcommerce.api
@@ -16,6 +17,13 @@ class TestBigcommerceApi(unittest.TestCase):
     def test_create_oauth(self):
         api = bigcommerce.api.BigcommerceApi(client_id='123456', store_hash='abcdef', access_token='123abc')
         self.assertIsInstance(api.connection, OAuthConnection)
+
+    def test_alternate_api_endpoint_from_env(self):
+        os.environ['BC_API_ENDPOINT'] = 'foobar.com'
+        api = bigcommerce.api.BigcommerceApi(client_id='123456', store_hash='abcdef', access_token='123abc')
+        self.assertIsInstance(api.connection, OAuthConnection)
+        self.assertEqual(api.connection.full_path('time'), 'https://foobar.com/stores/abcdef/v2/time')
+        del os.environ['BC_API_ENDPOINT']
 
     def test_create_incorrect_args(self):
         self.assertRaises(Exception, lambda: bigcommerce.api.BigcommerceApi(client_id='123', basic_auth=('admin', 'token')))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -97,6 +97,10 @@ class TestOAuthConnection(unittest.TestCase):
         connection = OAuthConnection(client_id='123', store_hash='abcdef')
         self.assertEqual(connection.full_path('time'), 'https://api.bigcommerce.com/stores/abcdef/v2/time')
 
+    def test_alternate_api_endpoint(self):
+        connection = OAuthConnection(client_id='123', store_hash='abcdef', host='barbaz.com')
+        self.assertEqual(connection.full_path('time'), 'https://barbaz.com/stores/abcdef/v2/time')
+
     def test_verify_payload(self):
         """Decode and verify signed payload."""
         payload = "eyJ1c2VyIjp7ImlkIjo3MiwiZW1haWwiOiJqYWNraWUuaHV5bmh" \


### PR DESCRIPTION
* This change allows for an override of the default bigcommerce
  api endpoint by setting the environment variable BC_API_ENDPOINT
* Useful for testing