### PR TITLE
Add counting for resources and subresources

### DIFF
--- a/bigcommerce/resources/base.py
+++ b/bigcommerce/resources/base.py
@@ -178,11 +178,20 @@ class CountableApiResource(ApiResource):
 
 
 class CountableApiSubResource(ApiSubResource):
-    @classmethod
-    def _count_path(cls, parentid):
-        return "%s/%s/%s/count" % (cls.parent_resource, parentid, cls.resource_name)
+    # Account for the fairly common case where the count path doesn't include the parent id
+    count_resource = None
 
     @classmethod
-    def count(cls, parentid, connection=None, **params):
+    def _count_path(cls, parentid=None):
+        if cls.count_resource is not None:
+            return "%s/count" % (cls.count_resource)
+        elif parentid is not None:
+            return "%s/%s/%s/count" % (cls.parent_resource, parentid, cls.resource_name)
+        else:
+            # misconfiguration
+            raise NotImplementedError('Count not implemented for this resource.')
+
+    @classmethod
+    def count(cls, parentid=None, connection=None, **params):
         response = cls._make_request('GET', cls._count_path(parentid), connection, params=params)
         return response['count']

--- a/bigcommerce/resources/brands.py
+++ b/bigcommerce/resources/brands.py
@@ -3,5 +3,5 @@ from .base import *
 
 class Brands(ListableApiResource, CreateableApiResource,
              UpdateableApiResource, DeleteableApiResource,
-             CollectionDeleteableApiResource):
+             CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'brands'

--- a/bigcommerce/resources/categories.py
+++ b/bigcommerce/resources/categories.py
@@ -3,5 +3,5 @@ from .base import *
 
 class Categories(ListableApiResource, CreateableApiResource,
                  UpdateableApiResource, DeleteableApiResource,
-                 CollectionDeleteableApiResource):
+                 CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'categories'

--- a/bigcommerce/resources/countries.py
+++ b/bigcommerce/resources/countries.py
@@ -1,7 +1,7 @@
 from .base import *
 
 
-class Countries(ListableApiResource):
+class Countries(ListableApiResource, CountableApiResource):
     resource_name = 'countries'
 
     def states(self, id=None):
@@ -11,7 +11,7 @@ class Countries(ListableApiResource):
             return CountryStates.all(self.id, connection=self._connection)
 
 
-class CountryStates(ListableApiSubResource):
+class CountryStates(ListableApiSubResource, CountableApiSubResource):
     resource_name = 'states'
     parent_resource = 'countries'
     parent_key = 'country_id'

--- a/bigcommerce/resources/coupons.py
+++ b/bigcommerce/resources/coupons.py
@@ -3,5 +3,5 @@ from .base import *
 
 class Coupons(ListableApiResource, CreateableApiResource,
               UpdateableApiResource, DeleteableApiResource,
-              CollectionDeleteableApiResource):
+              CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'coupons'

--- a/bigcommerce/resources/customer_groups.py
+++ b/bigcommerce/resources/customer_groups.py
@@ -3,5 +3,5 @@ from .base import *
 
 class CustomerGroups(ListableApiResource, CreateableApiResource,
                      UpdateableApiResource, DeleteableApiResource,
-                     CollectionDeleteableApiResource):
+                     CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'customer_groups'

--- a/bigcommerce/resources/customers.py
+++ b/bigcommerce/resources/customers.py
@@ -3,7 +3,7 @@ from .base import *
 
 class Customers(ListableApiResource, CreateableApiResource,
                 UpdateableApiResource, DeleteableApiResource,
-                CollectionDeleteableApiResource):
+                CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'customers'
 
     def addresses(self, id=None):
@@ -15,7 +15,7 @@ class Customers(ListableApiResource, CreateableApiResource,
 
 class CustomerAddresses(ListableApiSubResource, CreateableApiSubResource,
                         UpdateableApiSubResource, DeleteableApiSubResource,
-                        CollectionDeleteableApiSubResource):
+                        CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'addresses'
     parent_resource = 'customers'
     parent_key = 'customer_id'

--- a/bigcommerce/resources/option_sets.py
+++ b/bigcommerce/resources/option_sets.py
@@ -3,7 +3,7 @@ from .base import *
 
 class OptionSets(ListableApiResource, CreateableApiResource,
                  UpdateableApiResource, DeleteableApiResource,
-                 CollectionDeleteableApiResource):
+                 CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'option_sets'
 
     def options(self, id=None):

--- a/bigcommerce/resources/options.py
+++ b/bigcommerce/resources/options.py
@@ -3,7 +3,7 @@ from .base import *
 
 class Options(ListableApiResource, CreateableApiResource,
               UpdateableApiResource, DeleteableApiResource,
-              CollectionDeleteableApiResource):
+              CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'options'
 
     def values(self, id=None):

--- a/bigcommerce/resources/orders.py
+++ b/bigcommerce/resources/orders.py
@@ -3,7 +3,7 @@ from .base import *
 
 class Orders(ListableApiResource, CreateableApiResource,
              UpdateableApiResource, DeleteableApiResource,
-             CollectionDeleteableApiResource):
+             CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'orders'
 
     def coupons(self, id=None):
@@ -37,21 +37,24 @@ class OrderCoupons(ListableApiSubResource):
     parent_key = 'order_id'
 
 
-class OrderProducts(ListableApiSubResource):
+class OrderProducts(ListableApiSubResource, CountableApiSubResource):
     resource_name = 'products'
     parent_resource = 'orders'
     parent_key = 'order_id'
+    count_resource = 'orders/products'
 
 
 class OrderShipments(ListableApiSubResource, CreateableApiSubResource,
                      UpdateableApiSubResource, DeleteableApiSubResource,
-                     CollectionDeleteableApiSubResource):
+                     CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'shipments'
     parent_resource = 'orders'
     parent_key = 'order_id'
+    count_resource = 'orders/shipments'
 
 
-class OrderShippingAddresses(ListableApiSubResource):
+class OrderShippingAddresses(ListableApiSubResource, CountableApiSubResource):
     resource_name = 'shipping_addresses'
     parent_resource = 'orders'
     parent_key = 'order_id'
+    count_resource = 'orders/shipping_addresses'

--- a/bigcommerce/resources/products.py
+++ b/bigcommerce/resources/products.py
@@ -56,34 +56,38 @@ class Products(ListableApiResource, CreateableApiResource,
 
 
 class ProductConfigurableFields(ListableApiSubResource, DeleteableApiSubResource,
-                                CollectionDeleteableApiSubResource):
+                                CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'configurable_fields'
     parent_resource = 'products'
     parent_key = 'product_id'
+    count_resource = 'products/configurable_fields'
 
 
 class ProductCustomFields(ListableApiSubResource, CreateableApiSubResource,
                           UpdateableApiSubResource, DeleteableApiSubResource,
-                          CollectionDeleteableApiSubResource):
+                          CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'custom_fields'
     parent_resource = 'products'
     parent_key = 'product_id'
+    count_resource = 'products/custom_fields'
 
 
 class ProductDiscountRules(ListableApiSubResource, CreateableApiSubResource,
                            UpdateableApiSubResource, DeleteableApiSubResource,
-                           CollectionDeleteableApiSubResource):
+                           CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'discount_rules'
     parent_resource = 'products'
     parent_key = 'product_id'
+    count_resource = 'products/discount_rules'
 
 
 class ProductImages(ListableApiSubResource, CreateableApiSubResource,
                     UpdateableApiSubResource, DeleteableApiSubResource,
-                    CollectionDeleteableApiSubResource):
+                    CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'images'
     parent_resource = 'products'
     parent_key = 'product_id'
+    count_resource = 'products/images'
 
 
 class ProductOptions(ListableApiSubResource):
@@ -94,21 +98,24 @@ class ProductOptions(ListableApiSubResource):
 
 class ProductRules(ListableApiSubResource, CreateableApiSubResource,
                    UpdateableApiSubResource, DeleteableApiSubResource,
-                   CollectionDeleteableApiSubResource):
+                   CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'rules'
     parent_resource = 'products'
     parent_key = 'product_id'
+    count_resource = 'products/rules'
 
 
 class ProductSkus(ListableApiSubResource, CreateableApiSubResource,
                   UpdateableApiSubResource, DeleteableApiSubResource,
-                  CollectionDeleteableApiSubResource):
+                  CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'skus'
     parent_resource = 'products'
     parent_key = 'product_id'
+    count_resource = 'products/skus'
 
 
-class ProductVideos(ListableApiSubResource):
+class ProductVideos(ListableApiSubResource, CountableApiSubResource):
     resource_name = 'videos'
     parent_resource = 'products'
     parent_key = 'product_id'
+    count_resource = 'products/videos'

--- a/bigcommerce/resources/redirects.py
+++ b/bigcommerce/resources/redirects.py
@@ -3,5 +3,5 @@ from .base import *
 
 class Redirects(ListableApiResource, CreateableApiResource,
                 UpdateableApiResource, DeleteableApiResource,
-                CollectionDeleteableApiResource):
+                CollectionDeleteableApiResource, CountableApiResource):
     resource_name = 'redirects'

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,6 @@
 import unittest
-from bigcommerce.resources import Mapping, Orders, ApiResource, OrderShipments, Products
-from bigcommerce.resources.orders import OrderCoupons
-from bigcommerce.resources.webhooks import Webhooks
+from bigcommerce.resources import Mapping, Orders, ApiResource, OrderShipments, Products, CountryStates,\
+                                  OrderCoupons, Webhooks
 from mock import MagicMock
 
 
@@ -178,3 +177,19 @@ class TestCountableApiResource(unittest.TestCase):
 
         self.assertEqual(Products.count(connection, is_visible=True), 2)
         connection.make_request.assert_called_once_with('GET', 'products/count', None, {'is_visible': True}, {})
+
+
+class TestCountableApiSubResource(unittest.TestCase):
+    def test_count(self):
+        connection = MagicMock()
+        connection.make_request.return_value = {'count': 2}
+
+        self.assertEqual(CountryStates.count(1, connection=connection, is_visible=True), 2)
+        connection.make_request.assert_called_once_with('GET', 'countries/1/states/count', None, {'is_visible': True}, {})
+
+    def test_count_with_custom_count_path(self):
+        connection = MagicMock()
+        connection.make_request.return_value = {'count': 2}
+
+        self.assertEqual(OrderShipments.count(connection=connection, is_visible=True), 2)
+        connection.make_request.assert_called_once_with('GET', 'orders/shipments/count', None, {'is_visible': True}, {})


### PR DESCRIPTION
* Update CountableApiSubResource to account for the fairly common case
  where a subresource count is not scoped by parentid, but rather globally
  for the whole store.
* Add the CountableApiResource and CountableApiSubResource parent
  class to relevant resources and configure count_resource appropriately