### PR TITLE
BIG-22366

### DIFF
--- a/bigcommerce/resources/base.py
+++ b/bigcommerce/resources/base.py
@@ -183,10 +183,10 @@ class CountableApiSubResource(ApiSubResource):
 
     @classmethod
     def _count_path(cls, parentid=None):
-        if cls.count_resource is not None:
-            return "%s/count" % (cls.count_resource)
-        elif parentid is not None:
+        if parentid is not None:
             return "%s/%s/%s/count" % (cls.parent_resource, parentid, cls.resource_name)
+        elif cls.count_resource is not None:
+            return "%s/count" % (cls.count_resource)
         else:
             # misconfiguration
             raise NotImplementedError('Count not implemented for this resource.')


### PR DESCRIPTION
Evaluating these if statements in the wrong priority order meant that
we were always returning the count path for the subresource storewide
if count was implemented at all. Now we correctly check for a parent ID
and return the correct path if present.