### PR TITLE
BIG-27110 - Add support for customer login tokens

### DIFF
--- a/bigcommerce/__init__.py
+++ b/bigcommerce/__init__.py
@@ -2,3 +2,4 @@
 #     EmptyResponseWarning, RedirectionException, ServerException
 import bigcommerce.resources
 import bigcommerce.api
+from bigcommerce.customer_login_token import CustomerLoginTokens as customer_login_token

--- a/bigcommerce/customer_login_token.py
+++ b/bigcommerce/customer_login_token.py
@@ -1,0 +1,50 @@
+import os
+import time
+import uuid
+import jwt
+
+
+class CustomerLoginTokens(object):
+    @classmethod
+    def create(cls, client, id, redirect_url=None, request_ip=None):
+        
+        # Get the client_secret needed to sign tokens from the environment
+        # Intended to play nice with the Python Hello World sample app
+        # https://github.com/bigcommerce/hello-world-app-python-flask
+        client_secret = os.getenv('APP_CLIENT_SECRET')
+        
+        if not client_secret:
+            raise AttributeError('No OAuth client secret specified in the environment, '
+                                 'please specify an APP_CLIENT_SECRET')
+
+        try:
+            client_id = client.connection.client_id
+            store_hash = client.connection.store_hash
+        except AttributeError:
+            raise AttributeError('Store hash or client ID not found in the connection - '
+                                 'make sure an OAuth API connection is configured. Basic auth is not supported.')
+
+        payload = dict(iss=client_id,
+                       iat=int(time.time()),
+                       jti=uuid.uuid4().hex,
+                       operation='customer_login',
+                       store_hash=store_hash,
+                       customer_id=id
+                       )
+
+        if redirect_url:
+            payload['redirect_url'] = redirect_url
+
+        if request_ip:
+            payload['request_ip'] = request_ip
+        
+        token = jwt.encode(payload, client_secret, algorithm='HS256')
+        
+        return token.decode('utf-8')
+
+    @classmethod
+    def create_url(cls, client, id, redirect_url=None, request_ip=None):
+        secure_url = client.Store.all()['secure_url']
+        login_token = cls.create(client, id, redirect_url, request_ip)
+        return '%s/login/token/%s' % (secure_url, login_token)
+

--- a/examples/ex_login_token.py
+++ b/examples/ex_login_token.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import bigcommerce.api
+import bigcommerce.customer_login_token
+import os
+
+# Customer login tokens must be signed with an app secret loaded in the environment
+os.environ['APP_CLIENT_SECRET'] = 'client secret'
+
+# Create API object using OAuth credentials
+api = bigcommerce.api.BigcommerceApi(client_id='id', store_hash='hash', access_token='token')
+
+# Create a new customer
+api.Customers.create(first_name='Bob', last_name='Johnson', email='bob.johnson@example.com')
+
+# Or get the customer if they already exist
+customer = api.Customers.all(email='bob.johnson@example.com')[0]
+
+# Create the JWT login token
+login_token = bigcommerce.customer_login_token.create(api, customer.id)
+
+print('Token: %s' % login_token)
+
+# You can build the URL yourself
+print('%s/login/token/%s' % ('https://domain.com', login_token))
+
+# Or use the helper method to build the URL (uses 1 API request to get the secure domain for the store)
+login_token_url = bigcommerce.customer_login_token.create_url(api, customer.id)
+print('Token URL: %s' % login_token_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ nose==1.3.0
 nose-cov==1.6
 requests==2.1.0
 streql==3.0.2
+pyjwt==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version = '0.14.0',
 
     packages = find_packages(),
-    install_requires = ['requests>=2.1.0', 'streql>=3.0.2'],
+    install_requires = ['requests>=2.1.0', 'streql>=3.0.2', 'pyjwt>=1.4.0'],
 
     url = 'https://github.com/bigcommerce/bigcommerce-api-python',
     download_url = 'https://github.com/bigcommerce/bigcommerce-api-python/releases',


### PR DESCRIPTION
Adding support for JWT-based customer login tokens.

Adds a method for creating the proper token using an OAuth app's client secret and other details, as well as a helper method for creating an entire URL.

Also adds an example.