### PR TITLE
API-719 - Add more information about rate limiting to the connection class

### DIFF
--- a/bigcommerce/exception.py
+++ b/bigcommerce/exception.py
@@ -29,6 +29,10 @@ class ClientRequestException(HttpException):
     pass
 
 class RateLimitingException(ClientRequestException):
+    @property
+    def retry_after(self):
+        return self.response.headers['X-Rate-Limit-Time-Reset-Ms']
+
     pass
 # class Unauthorised(ClientRequestException): pass
 # class AccessForbidden(ClientRequestException): pass


### PR DESCRIPTION
#### What?

OAuth connections now get a lot more information about where they are in the rate limiting algorithm via new headers. This PR stores the headers from the most recent request on the connection class so applications can anticipate the rate limiter and throttle themselves.

Tested using production API credentials.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [API-719](https://jira.bigcommerce.com/browse/API-719)