### PR TITLE
Resolved conflict of standard python dict function items with _items

### DIFF
--- a/bigcommerce/resources/base.py
+++ b/bigcommerce/resources/base.py
@@ -14,6 +14,7 @@ class Mapping(dict):
         of being replaced by the dict describing the coupons endpoint
         """
         filter_args = {k: mapping[k] for k in mapping if k not in dir(self)}
+	filter_args['_items'] = mapping['items'] if  mapping.has_key("items") else [] #Changed/Newly Added
         self.__dict__ = self
         dict.__init__(self, filter_args, *args, **kwargs)
 


### PR DESCRIPTION
#### Bug detected while fetching  OrderShipments items from  Big Commerce Store

When i tried to fetch the OrderShipments from Big Commerce Store, it does not include shipping items within OrderShipments object, because items is a standard dict function and  while creating object it doesn't include items attributes in OrderShipments object as you have applied the condition **if key not in dir(self)**.

#### Used _items to  traverse the items instead of calling standard items function on dict object if  its including in response.