### PR TITLE
Remove dependency on streql

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Bigcommerce API Python Client
 Wrapper over the ``requests`` library for communicating with the Bigcommerce v2 API.
 
 Install with ``pip install bigcommerce`` or ``easy_install bigcommerce``. Tested with
-python 2.7 and 3.4, and only requires ``requests`` and ``streql``.
+python 2.7.7+ and 3.4, and only requires ``requests`` and ``pyjwt``.
 
 Usage
 -----

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -14,7 +14,6 @@ except ImportError:
 
 import json  # only used for urlencode querystr
 import logging
-import streql
 import requests
 
 from bigcommerce.exception import *
@@ -216,7 +215,7 @@ class OAuthConnection(Connection):
         dc_json = base64.b64decode(encoded_json)
         signature = base64.b64decode(encoded_hmac)
         expected_sig = hmac.new(client_secret.encode(), base64.b64decode(encoded_json), hashlib.sha256).hexdigest()
-        authorised = streql.equals(signature, expected_sig)
+        authorised = hmac.compare_digest(signature, expected_sig.encode())
         return json.loads(dc_json.decode()) if authorised else False
 
     def fetch_token(self, client_secret, code, context, scope, redirect_uri,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ mock==1.0.1
 nose==1.3.0
 nose-cov==1.6
 requests==2.1.0
-streql==3.0.2
 pyjwt==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version = VERSION,
 
     packages = find_packages(),
-    install_requires = ['requests>=2.1.0', 'streql>=3.0.2', 'pyjwt>=1.4.0'],
+    install_requires = ['requests>=2.1.0', 'pyjwt>=1.4.0'],
     
     
     url = 'https://github.com/bigcommerce/bigcommerce-api-python',


### PR DESCRIPTION
Fixes https://github.com/bigcommerce/bigcommerce-api-python/issues/9

streql is no longer necessary in python 2.7.7+ as there is an equivalent function in stdlib: https://docs.python.org/2/library/hmac.html#hmac.compare_digest

This removes the dependency which should also make this library easier to use for those on Windows.