### PR TITLE
iter_all() Automatic Paging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 *.pyc
 ENV/
+
+#PyCharm
+.idea/
+
+Pipfile
+Pipfile.lock
+
+*.egg-info*

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,9 @@ provides CRUD operations, depending on capabilities of the resource:
 
 .. code:: python
 
-    api.Products.all()                         # GET /products
+    api.Products.all()                         # GET /products (returns only a single page of products as a list)
+    api.Products.iterall()                     # GET /products (autopaging generator that yields all
+                                               #                  products from all pages product by product.)
     api.Products.get(1)                        # GET /products/1
     api.Products.create(name='', type='', ...) # POST /products
     api.Products.get(1).update(price='199.90') # PUT /products/1
@@ -110,7 +112,7 @@ Full documentation of the API is available on the Bigcommerce
 To do
 -----
 
--  Automatic enumeration of multiple page responses
+-  Automatic enumeration of multiple page responses for subresources.
 
 .. |Build Status| image:: https://api.travis-ci.org/bigcommerce/bigcommerce-api-python.svg?branch=master
    :target: https://travis-ci.org/bigcommerce/bigcommerce-api-python

--- a/bigcommerce/__init__.py
+++ b/bigcommerce/__init__.py
@@ -1,5 +1,3 @@
-# from bigcommerce.connection import Connection, OAuthConnection, HttpException, ClientRequestException, \
-#     EmptyResponseWarning, RedirectionException, ServerException
 import bigcommerce.resources
 import bigcommerce.api
 from bigcommerce.customer_login_token import CustomerLoginTokens as customer_login_token

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -177,7 +177,7 @@ class OAuthConnection(Connection):
     """
 
     def __init__(self, client_id, store_hash, access_token=None, host='api.bigcommerce.com', api_path='/stores/{}/v2/{}'):
-        super().__init__(host, None, api_path)
+        super(OAuthConnection, self).__init__(host, None, api_path)
 
         self.client_id = client_id
         self.store_hash = store_hash

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -26,7 +26,7 @@ class Connection(object):
     Connection class manages the connection to the Bigcommerce REST API.
     """
 
-    def __init__(self, host, auth, api_path='/api/v2/{}'):
+    def __init__(self, host, auth=None, api_path='/api/v2/{}'):
         self.host = host
         self.api_path = api_path
 
@@ -44,7 +44,7 @@ class Connection(object):
     def full_path(self, url):
         return "https://" + self.host + self.api_path.format(url)
 
-    def _run_method(self, method, url, data=None, query={}, headers={}):
+    def _run_method(self, method, url, data=None, query=None, headers=None):
         # make full path if not given
         if url and url[:4] != "http":
             if url[0] == '/':  # can call with /resource if you want
@@ -53,19 +53,18 @@ class Connection(object):
         elif not url:  # blank path
             url = self.full_path(url)
 
-        qs = urlencode(query)
+        qs = urlencode(query if query else {})
         if qs:
             qs = "?" + qs
         url += qs
 
         # mess with content
         if data:
-            if not headers:  # assume JSON
-                data = json.dumps(data)
-                headers = {'Content-Type': 'application/json'}
-            if headers and 'Content-Type' not in headers:
-                data = json.dumps(data)
-                headers['Content-Type'] = 'application/json'
+            headers = headers or {}
+            headers.setdefault('Content-Type', 'application/json')
+
+            data = json.dumps(data)
+
         log.debug("%s %s" % (method, url))
         # make and send the request
         return self._session.request(method, url, data=data, timeout=self.timeout, headers=headers)
@@ -118,7 +117,7 @@ class Connection(object):
 
     # Raw-er stuff
 
-    def make_request(self, method, url, data=None, params = {}, headers = {}):
+    def make_request(self, method, url, data=None, params=None, headers=None):
         response = self._run_method(method, url, data, params, headers)
         return self._handle_response(url, response)
 
@@ -143,11 +142,11 @@ class Connection(object):
         """
         Returns parsed JSON or raises an exception appropriately.
         """
+
         self._last_response = res
-        result = {}
         if res.status_code in (200, 201, 202):
             try:
-                result = res.json()
+                return res.json()
             except Exception as e:  # json might be invalid, or store might be down
                 e.message += " (_handle_response failed to decode JSON: " + str(res.content) + ")"
                 raise  # TODO better exception
@@ -161,7 +160,6 @@ class Connection(object):
             raise ClientRequestException("%d %s @ %s: %s" % (res.status_code, res.reason, url, res.content), res)
         elif res.status_code >= 300:
             raise RedirectionException("%d %s @ %s: %s" % (res.status_code, res.reason, url, res.content), res)
-        return result
 
     def __repr__(self):
         return "%s %s%s" % (self.__class__.__name__, self.host, self.api_path)
@@ -179,19 +177,14 @@ class OAuthConnection(Connection):
     """
 
     def __init__(self, client_id, store_hash, access_token=None, host='api.bigcommerce.com', api_path='/stores/{}/v2/{}'):
+        super().__init__(host, None, api_path)
+
         self.client_id = client_id
         self.store_hash = store_hash
-        self.host = host
-        self.api_path = api_path
-        self.timeout = 7.0  # can attach to session?
+        self._session.headers.update({"Accept-Encoding": "gzip"})
 
-        self._session = requests.Session()
-        self._session.headers = {"Accept": "application/json",
-                                 "Accept-Encoding": "gzip"}
         if access_token and store_hash:
             self._session.headers.update(self._oauth_headers(client_id, access_token))
-
-        self._last_response = None  # for debugging
 
         self.rate_limit = {}
 

--- a/bigcommerce/resources/base.py
+++ b/bigcommerce/resources/base.py
@@ -99,7 +99,19 @@ class ListableApiResource(ApiResource):
         return cls.resource_name
 
     @classmethod
-    def all(cls, connection=None, **kwargs):
+    def all(cls, connection=None, **params):
+        """
+            Returns first page if no params passed in as a list.
+        """
+
+        request = cls._make_request('GET', cls._get_all_path(), connection, params=params)
+        return cls._create_object(request, connection=connection)
+
+    @classmethod
+    def iterall(cls, connection=None, **kwargs):
+        """
+            Returns a autopaging generator that yields each object returned one by one.
+        """
 
         try:
             limit = kwargs['limit']

--- a/bigcommerce/resources/base.py
+++ b/bigcommerce/resources/base.py
@@ -132,7 +132,8 @@ class ListableApiResource(ApiResource):
 
         else:
             response = cls._make_request('GET', cls._get_all_path(), connection, params=kwargs)
-            yield from cls._create_object(response, connection=connection)
+            for obj in cls._create_object(response, connection=connection):
+                yield obj
 
 
 class ListableApiSubResource(ApiSubResource):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -45,7 +45,7 @@ class TestApiResource(unittest.TestCase):
         self.assertIsInstance(result, Orders)
         self.assertEqual(result.id, 1)
 
-        connection.make_request.assert_called_once_with('GET', 'orders/1', None, {}, {})
+        connection.make_request.assert_called_once_with('GET', 'orders/1', None, {}, None)
 
 
 class TestApiSubResource(unittest.TestCase):
@@ -57,7 +57,7 @@ class TestApiSubResource(unittest.TestCase):
         self.assertIsInstance(result, OrderCoupons)
         self.assertEqual(result.id, 2)
 
-        connection.make_request.assert_called_once_with('GET', 'orders/1/coupons/2', None, {}, {})
+        connection.make_request.assert_called_once_with('GET', 'orders/1/coupons/2', None, {}, None)
 
     def test_parent_id(self):
         coupon = OrderCoupons({'id': 2, 'order_id': 1})
@@ -72,7 +72,7 @@ class TestCreateableApiResource(unittest.TestCase):
         result = Orders.create(connection, name="Hello")
         self.assertIsInstance(result, Orders)
         self.assertEqual(result.id, 1)
-        connection.make_request.assert_called_once_with('POST', 'orders', {'name': 'Hello'}, {}, {})
+        connection.make_request.assert_called_once_with('POST', 'orders', {'name': 'Hello'}, None, None)
 
 
 class TestCreateableApiSubResource(unittest.TestCase):
@@ -83,17 +83,17 @@ class TestCreateableApiSubResource(unittest.TestCase):
         result = OrderShipments.create(1, connection, name="Hello")
         self.assertIsInstance(result, OrderShipments)
         self.assertEqual(result.id, 2)
-        connection.make_request.assert_called_once_with('POST', 'orders/1/shipments', {'name': 'Hello'}, {}, {})
+        connection.make_request.assert_called_once_with('POST', 'orders/1/shipments', {'name': 'Hello'}, None, None)
 
 
 class TestListableApiResource(unittest.TestCase):
     def test_all(self):
         connection = MagicMock()
-        connection.make_request.return_value = [{'id': 1}, {'id': 2}]
+        connection.make_request.return_value = [{'id': 1}, {'id': 2}, {'id': 2}]
 
-        result = Orders.all(connection, limit=2)
-        self.assertEqual(len(result), 2)
-        connection.make_request.assert_called_once_with('GET', 'orders', None, {'limit': 2}, {})
+        result = Orders.all(connection, limit=3)
+        self.assertEqual(len(list(result)), 3)
+        connection.make_request.assert_called_once_with('GET', 'orders', None, {'limit': 3}, None)
 
 
 class TestListableApiSubResource(unittest.TestCase):
@@ -103,7 +103,7 @@ class TestListableApiSubResource(unittest.TestCase):
 
         result = OrderCoupons.all(1, connection, limit=2)
         self.assertEqual(len(result), 2)
-        connection.make_request.assert_called_once_with('GET', 'orders/1/coupons', None, {'limit': 2}, {})
+        connection.make_request.assert_called_once_with('GET', 'orders/1/coupons', None, {'limit': 2}, None)
 
     def test_google_mappings(self):
         connection = MagicMock()
@@ -111,7 +111,7 @@ class TestListableApiSubResource(unittest.TestCase):
 
         result = GoogleProductSearchMappings.all(1, connection, limit=2)
         self.assertEqual(len(result), 2)
-        connection.make_request.assert_called_once_with('GET', 'products/1/googleproductsearch', None, {'limit': 2}, {})
+        connection.make_request.assert_called_once_with('GET', 'products/1/googleproductsearch', None, {'limit': 2}, None)
 
 
 class TestUpdateableApiResource(unittest.TestCase):
@@ -123,7 +123,7 @@ class TestUpdateableApiResource(unittest.TestCase):
         new_order = order.update(name='order')
         self.assertIsInstance(new_order, Orders)
 
-        connection.make_request.assert_called_once_with('PUT', 'orders/1', {'name': 'order'}, {}, {})
+        connection.make_request.assert_called_once_with('PUT', 'orders/1', {'name': 'order'}, None, None)
 
 
 class TestUpdateableApiSubResource(unittest.TestCase):
@@ -136,7 +136,7 @@ class TestUpdateableApiSubResource(unittest.TestCase):
         self.assertIsInstance(new_order, OrderShipments)
 
         connection.make_request.assert_called_once_with('PUT', 'orders/2/shipments/1', {'tracking_number': '1234'},
-                                                        {}, {})
+                                                        None, None)
 
 
 class TestDeleteableApiResource(unittest.TestCase):
@@ -146,7 +146,7 @@ class TestDeleteableApiResource(unittest.TestCase):
 
         self.assertEqual(Orders.delete_all(connection), {})
 
-        connection.make_request.assert_called_once_with('DELETE', 'orders', None, {}, {})
+        connection.make_request.assert_called_once_with('DELETE', 'orders', None, None, None)
 
     def test_delete(self):
         connection = MagicMock()
@@ -156,7 +156,7 @@ class TestDeleteableApiResource(unittest.TestCase):
 
         self.assertEqual(order.delete(), {})
 
-        connection.make_request.assert_called_once_with('DELETE', 'orders/1', None, {}, {})
+        connection.make_request.assert_called_once_with('DELETE', 'orders/1', None, None, None)
 
 
 class TestDeleteableApiSubResource(unittest.TestCase):
@@ -166,7 +166,7 @@ class TestDeleteableApiSubResource(unittest.TestCase):
 
         self.assertEqual(OrderShipments.delete_all(1, connection=connection), {})
 
-        connection.make_request.assert_called_once_with('DELETE', 'orders/1/shipments', None, {}, {})
+        connection.make_request.assert_called_once_with('DELETE', 'orders/1/shipments', None, None, None)
 
     def test_delete(self):
         connection = MagicMock()
@@ -175,7 +175,7 @@ class TestDeleteableApiSubResource(unittest.TestCase):
         shipment = OrderShipments({'id': 1, 'order_id': 2, '_connection': connection})
         self.assertEqual(shipment.delete(), {})
 
-        connection.make_request.assert_called_once_with('DELETE', 'orders/2/shipments/1', None, {}, {})
+        connection.make_request.assert_called_once_with('DELETE', 'orders/2/shipments/1', None, None, None)
 
 
 class TestCountableApiResource(unittest.TestCase):
@@ -184,7 +184,7 @@ class TestCountableApiResource(unittest.TestCase):
         connection.make_request.return_value = {'count': 2}
 
         self.assertEqual(Products.count(connection, is_visible=True), 2)
-        connection.make_request.assert_called_once_with('GET', 'products/count', None, {'is_visible': True}, {})
+        connection.make_request.assert_called_once_with('GET', 'products/count', None, {'is_visible': True}, None)
 
 
 class TestCountableApiSubResource(unittest.TestCase):
@@ -193,11 +193,13 @@ class TestCountableApiSubResource(unittest.TestCase):
         connection.make_request.return_value = {'count': 2}
 
         self.assertEqual(CountryStates.count(1, connection=connection, is_visible=True), 2)
-        connection.make_request.assert_called_once_with('GET', 'countries/1/states/count', None, {'is_visible': True}, {})
+        connection.make_request.assert_called_once_with('GET', 'countries/1/states/count',
+                                                        None, {'is_visible': True}, None)
 
     def test_count_with_custom_count_path(self):
         connection = MagicMock()
         connection.make_request.return_value = {'count': 2}
 
         self.assertEqual(OrderShipments.count(connection=connection, is_visible=True), 2)
-        connection.make_request.assert_called_once_with('GET', 'orders/shipments/count', None, {'is_visible': True}, {})
+        connection.make_request.assert_called_once_with('GET', 'orders/shipments/count',
+                                                        None, {'is_visible': True}, None)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -130,25 +130,25 @@ class TestOAuthConnection(unittest.TestCase):
         scope = 'store_v2_products'
         redirect_uri = 'http://localhost/callback'
         result = {'access_token': '12345abcdef'}
-        with patch('bigcommerce.connection.OAuthConnection') as mock:
-            connection = OAuthConnection(client_id, store_hash='abc')
-            connection.post = MagicMock()
-            connection.post.return_value = result
 
-            res = connection.fetch_token(client_secret, code, context, scope, redirect_uri)
-            self.assertEqual(res, result)
-            self.assertDictEqual(connection._session.headers,
-                                 {'X-Auth-Client': 'abc123', 'X-Auth-Token': '12345abcdef',
-                                  'Accept': 'application/json', 'Accept-Encoding': 'gzip'})
-            connection.post.assert_called_once_with('https://login.bigcommerce.com/oauth2/token',
-                                                    {
-                                                        'client_id': client_id,
-                                                        'client_secret': client_secret,
-                                                        'code': code,
-                                                        'context': context,
-                                                        'scope': scope,
-                                                        'grant_type': 'authorization_code',
-                                                        'redirect_uri': redirect_uri
-                                                    },
-                                                    headers={'Content-Type': 'application/x-www-form-urlencoded'}
+        connection = OAuthConnection(client_id, store_hash='abc')
+        connection.post = MagicMock()
+        connection.post.return_value = result
+
+        res = connection.fetch_token(client_secret, code, context, scope, redirect_uri)
+        self.assertEqual(res, result)
+        self.assertDictEqual(connection._session.headers,
+                             {'X-Auth-Client': 'abc123', 'X-Auth-Token': '12345abcdef',
+                              'Accept': 'application/json', 'Accept-Encoding': 'gzip'})
+        connection.post.assert_called_once_with('https://login.bigcommerce.com/oauth2/token',
+                                                {
+                                                    'client_id': client_id,
+                                                    'client_secret': client_secret,
+                                                    'code': code,
+                                                    'context': context,
+                                                    'scope': scope,
+                                                    'grant_type': 'authorization_code',
+                                                    'redirect_uri': redirect_uri
+                                                },
+                                                headers={'Content-Type': 'application/x-www-form-urlencoded'}
             )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -21,13 +21,13 @@ class TestConnection(unittest.TestCase):
         # Call with nothing
         connection._run_method('GET', '')
         connection._session.request.assert_called_once_with('GET', 'https://store.mybigcommerce.com/api/v2/',
-                                                            data=None, timeout=7.0, headers={})
+                                                            data=None, timeout=7.0, headers=None)
         connection._session.request.reset_mock()
 
         # A simple request
         connection._run_method('GET', 'time')
         connection._session.request.assert_called_once_with('GET', 'https://store.mybigcommerce.com/api/v2/time',
-                                                            data=None, timeout=7.0, headers={})
+                                                            data=None, timeout=7.0, headers=None)
         connection._session.request.reset_mock()
 
         # A request with data
@@ -47,7 +47,7 @@ class TestConnection(unittest.TestCase):
         connection._run_method('GET', '/orders', query={'limit': 50})
         connection._session.request.assert_called_once_with('GET',
                                                             'https://store.mybigcommerce.com/api/v2/orders?limit=50',
-                                                            data=None, timeout=7.0, headers={})
+                                                            data=None, timeout=7.0, headers=None)
         connection._session.request.reset_mock()
 
     def test_handle_response(self):


### PR DESCRIPTION
#### What?

Main thing is I added automatic paging to the `all` method of `ListableApiResource`.  With this pull it returns a generator with _all_ of the objects. It does this by requesting pages from the api till it returns a empty list.

Also cleaned up some warts i found while going thought the code.

Happy to take a similar approach for ListableApiSubResource resource however I am not sure of the semantics of paging subresources.
