### PR TITLE
Add option to use BC as source of truth for time for Customer Login API

### DIFF
--- a/bigcommerce/customer_login_token.py
+++ b/bigcommerce/customer_login_token.py
@@ -6,7 +6,7 @@ import jwt
 
 class CustomerLoginTokens(object):
     @classmethod
-    def create(cls, client, id, redirect_url=None, request_ip=None):
+    def create(cls, client, id, redirect_url=None, request_ip=None, iat_time=None):
         
         # Get the client_secret needed to sign tokens from the environment
         # Intended to play nice with the Python Hello World sample app
@@ -32,6 +32,9 @@ class CustomerLoginTokens(object):
                        customer_id=id
                        )
 
+        if iat_time:
+            payload['iat'] = iat_time
+
         if redirect_url:
             payload['redirect_to'] = redirect_url
 
@@ -43,8 +46,12 @@ class CustomerLoginTokens(object):
         return token.decode('utf-8')
 
     @classmethod
-    def create_url(cls, client, id, redirect_url=None, request_ip=None):
+    def create_url(cls, client, id, redirect_url=None, request_ip=None, use_bc_time=False):
         secure_url = client.Store.all()['secure_url']
-        login_token = cls.create(client, id, redirect_url, request_ip)
+        iat_time = None
+        if use_bc_time:
+            iat_time = client.Time.all()['time']
+            login_token = cls.create(client, id, redirect_url, request_ip, iat_time=iat_time)
+        else:
+            login_token = cls.create(client, id, redirect_url, request_ip)
         return '%s/login/token/%s' % (secure_url, login_token)
-

--- a/examples/ex_login_token.py
+++ b/examples/ex_login_token.py
@@ -23,6 +23,7 @@ print('Token: %s' % login_token)
 # You can build the URL yourself
 print('%s/login/token/%s' % ('https://domain.com', login_token))
 
-# Or use the helper method to build the URL (uses 1 API request to get the secure domain for the store)
-login_token_url = bigcommerce.customer_login_token.create_url(api, customer.id)
+# Or use the helper method to build the URL. This uses 1 API request to get the secure domain for the store, 
+# and another API request if you opt to use BC's clock for the iat.
+login_token_url = bigcommerce.customer_login_token.create_url(api, customer.id, use_bc_time=True)
 print('Token URL: %s' % login_token_url)


### PR DESCRIPTION
This should eliminate issues related to the application's server time being out of sync with BigCommerce, which is a common reason for failures of the Customer Login API.

ping @tatiana-perry @nikita-ahuja