### PR TITLE
Update requests to 2.20.0 due to vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ coverage==3.7.1
 mock==1.0.1
 nose==1.3.0
 nose-cov==1.6
-requests==2.1.0
+requests==2.20.0
 pyjwt==1.4.0


### PR DESCRIPTION
#### What?

There's a vulnerability in versions of `requests` older than 2.20.0. GitHub recommends upgrading.