### PR TITLE
Automatic handling of OAuth rate limit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,30 @@ wrapper around a lower level api in ``bigcommerce.connection``. This can
 be accessed through ``api.connection``, and provides helper methods for
 get/post/put/delete operations.
 
+Managing OAuth Rate Limits
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can optionally pass a ``rate_limiting_management`` object into ``bigcommerce.api.BigcommerceApi`` or ``bigcommerce.connection.OAuthConnection`` for automatic rate limiting management, ex:
+
+.. code:: python
+
+    import bigcommerce
+
+    api = bigcommerce.api.BigcommerceApi(client_id='', store_hash='', access_token=''
+                                         rate_limiting_management= {'min_requests_remaining':2,
+                                                                    'wait':True,
+                                                                    'callback_function':None})
+
+``min_requests_remaining`` will determine the number of requests remaining in the rate limiting window which will invoke the management function
+
+``wait`` determines whether or not we should automatically sleep until the end of the window
+
+``callback_function`` is a function to run when the rate limiting management function fires. It will be invoked *after* the wait, if enabled.
+
+``callback_args`` is an optional parameter which is a dictionary passed as an argument to the callback function.
+
+For simple applications which run API requests in serial (and aren't interacting with many different stores, or use a separate worker for each store) the simple sleep function may work well enough for most purposes. For more complex applications that may be parallelizing API requests on a given store, it's adviseable to write your own callback function for handling the rate limiting, use a ``min_requests_remaining`` higher than your concurrency, and not use the default wait function.
+
 Further documentation
 ---------------------
 

--- a/bigcommerce/api.py
+++ b/bigcommerce/api.py
@@ -5,14 +5,16 @@ from bigcommerce.resources import *  # Needed for ApiResourceWrapper dynamic loa
 
 
 class BigcommerceApi(object):
-    def __init__(self, host=None, basic_auth=None, client_id=None, store_hash=None, access_token=None):
+    def __init__(self, host=None, basic_auth=None,
+                 client_id=None, store_hash=None, access_token=None, rate_limiting_management=None):
         self.api_service = os.getenv('BC_API_ENDPOINT', 'api.bigcommerce.com')
         self.auth_service = os.getenv('BC_AUTH_SERVICE', 'login.bigcommerce.com')
 
         if host and basic_auth:
             self.connection = connection.Connection(host, basic_auth)
         elif client_id and store_hash:
-            self.connection = connection.OAuthConnection(client_id, store_hash, access_token, self.api_service)
+            self.connection = connection.OAuthConnection(client_id, store_hash, access_token, self.api_service,
+                                                         rate_limiting_management=rate_limiting_management)
         else:
             raise Exception("Must provide either (client_id and store_hash) or (host and basic_auth)")
 


### PR DESCRIPTION
#### What?

Adds the ability to pass a `rate_limiting_management` parameter when instantiating the client to automatically react to the rate limit for you. Supports a simple ability to sleep until the end of the rate limiting window, or supply your own callback function.