### PR TITLE
Add settings/analytics endpoint

### DIFF
--- a/bigcommerce/resources/__init__.py
+++ b/bigcommerce/resources/__init__.py
@@ -21,3 +21,4 @@ from .store import *
 from .tax_classes import *
 from .time import *
 from .webhooks import *
+from .analytics_settings import *

--- a/bigcommerce/resources/analytics_settings.py
+++ b/bigcommerce/resources/analytics_settings.py
@@ -1,0 +1,5 @@
+from .base import *
+
+
+class AnalyticsSettings(ListableApiResource, UpdateableApiResource):
+    resource_name = 'settings/analytics'


### PR DESCRIPTION
#### What?

Add the analytics settings endpoint, which allows you to get the Google Analytics and Facebook Pixel IDs as well as set them.

Example usage:

```
api = bigcommerce.api.BigcommerceApi(client_id='', store_hash='', access_token='')
api.AnalyticsSettings.all()
google_analytics = api.AnalyticsSettings.get(1)
google_analytics.update(code="UA-1234567")
```