### PR TITLE
Allow implicit options to be passed into product.sku

### DIFF
--- a/bigcommerce/resources/products.py
+++ b/bigcommerce/resources/products.py
@@ -48,11 +48,11 @@ class Products(ListableApiResource, CreateableApiResource,
         else:
             return ProductRules.all(self.id, connection=self._connection)
 
-    def skus(self, id=None):
+    def skus(self, id=None, **kwargs):
         if id:
-            return ProductSkus.get(self.id, id, connection=self._connection)
+            return ProductSkus.get(self.id, id, connection=self._connection, **kwargs)
         else:
-            return ProductSkus.all(self.id, connection=self._connection)
+            return ProductSkus.all(self.id, connection=self._connection, **kwargs)
 
     def videos(self, id=None):
         if id:


### PR DESCRIPTION
#### What?

Essentially we'd like to completely utilize the functionality already available to us when we call product.skus() - the underlying all() function allows us to pass product options, but we're limited within the product.skus() function to simply pass an id object. By allowing kwargs into product.skus() we can take advantage of the additional optionality within the all function. 

We could then do something neat like this. Implicitly specifying which pages to query. And I suspect we could also utilize the filter options as well - but I need to look into that.  

```python
    stop = False
    skuopts = {"limit": 250, "page": 1}
    while not stop:
       for sku in product.skus(**skuopts):
             print sku
       stop = True
```

#### Tickets / Documentation

- [Issue 18](https://github.com/bigcommerce/bigcommerce-api-python/issues/18)
