### PR TITLE
Auto sleep and retry requests when 429

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,10 @@ Connecting
 
     # Public apps (OAuth)
     # Access_token is optional, if you don't have one you can use oauth_fetch_token (see below)
+    # For connecting to the v2 api:
     api = bigcommerce.api.BigcommerceApi(client_id='', store_hash='', access_token='')
+    # For connecting to the v3 api:
+    api = bigcommerce.api.BigcommerceApi(client_id='', store_hash='', access_token='', api_path='/stores/{}/v3/{}'))
 
     # Private apps (Basic Auth)
     api = bigcommerce.api.BigcommerceApi(host='store.mybigcommerce.com', basic_auth=('username', 'api token'))

--- a/bigcommerce/api.py
+++ b/bigcommerce/api.py
@@ -5,7 +5,7 @@ from bigcommerce.resources import *  # Needed for ApiResourceWrapper dynamic loa
 
 
 class BigcommerceApi(object):
-    def __init__(self, host=None, basic_auth=None,
+    def __init__(self, host=None, api_path=None, basic_auth=None,
                  client_id=None, store_hash=None, access_token=None, rate_limiting_management=None):
         self.api_service = os.getenv('BC_API_ENDPOINT', 'api.bigcommerce.com')
         self.auth_service = os.getenv('BC_AUTH_SERVICE', 'login.bigcommerce.com')
@@ -14,6 +14,7 @@ class BigcommerceApi(object):
             self.connection = connection.Connection(host, basic_auth)
         elif client_id and store_hash:
             self.connection = connection.OAuthConnection(client_id, store_hash, access_token, self.api_service,
+                                                         api_path=api_path,
                                                          rate_limiting_management=rate_limiting_management)
         else:
             raise Exception("Must provide either (client_id and store_hash) or (host and basic_auth)")

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -53,6 +53,13 @@ class Connection(object):
         if headers is None:
             headers = {}
 
+        # Support v3
+        if self.api_path and 'v3' in self.api_path:
+            if url is 'orders':
+                self.api_path = self.api_path.replace('v3', 'v2')
+            else:
+                url = 'catalog/{}'.format(url)
+
         # make full path if not given
         if url and url[:4] != "http":
             if url[0] == '/':  # can call with /resource if you want
@@ -156,6 +163,9 @@ class Connection(object):
         if res.status_code in (200, 201, 202):
             try:
                 result = res.json()
+                # Support v3
+                if self.api_path and 'v3' in self.api_path:
+                    result = result['data']  # TODO ignore meta field for now
             except Exception as e:  # json might be invalid, or store might be down
                 e.message += " (_handle_response failed to decode JSON: " + str(res.content) + ")"
                 raise  # TODO better exception
@@ -187,11 +197,12 @@ class OAuthConnection(Connection):
     """
 
     def __init__(self, client_id, store_hash, access_token=None, host='api.bigcommerce.com',
-                 api_path='/stores/{}/v2/{}', rate_limiting_management=None):
+                 api_path=None, rate_limiting_management=None):
         self.client_id = client_id
         self.store_hash = store_hash
         self.host = host
         self.api_path = api_path
+        self.api_path = api_path if api_path else "/stores/{}/v2/{}"
         self.timeout = 7.0  # can attach to session?
         self.rate_limiting_management = rate_limiting_management
 

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -223,7 +223,7 @@ class OAuthConnection(Connection):
                          and self.rate_limiting_management.get('autoretry'))
 
             if (autoretry and 'X-Rate-Limit-Time-Reset-Ms' in response.headers):
-                sleep(int(response.headers['X-Rate-Limit-Time-Reset-Ms'])/1000)
+                sleep(ceil(float(response.headers['X-Rate-Limit-Time-Reset-Ms'])/1000))
                 return super(OAuthConnection, self).make_request(
                         *args, **kwargs)
             else:

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -253,7 +253,13 @@ class OAuthConnection(Connection):
         """
         Adds rate limiting information on to the response object
         """
-        result = Connection._handle_response(self, url, res, suppress_empty)
+        try:
+            result = Connection._handle_response(self, url, res, suppress_empty)
+        except RateLimitingException:
+            if not (self.rate_limiting_management
+                    and self.rate_limiting_management['wait']):
+                raise
+
         if 'X-Rate-Limit-Time-Reset-Ms' in res.headers:
             self.rate_limit = dict(ms_until_reset=int(res.headers['X-Rate-Limit-Time-Reset-Ms']),
                                    window_size_ms=int(res.headers['X-Rate-Limit-Time-Window-Ms']),

--- a/bigcommerce/resources/__init__.py
+++ b/bigcommerce/resources/__init__.py
@@ -20,4 +20,5 @@ from .shipping import *
 from .store import *
 from .tax_classes import *
 from .time import *
+from .variants import *
 from .webhooks import *

--- a/bigcommerce/resources/products.py
+++ b/bigcommerce/resources/products.py
@@ -48,11 +48,17 @@ class Products(ListableApiResource, CreateableApiResource,
         else:
             return ProductRules.all(self.id, connection=self._connection)
 
-    def skus(self, id=None):
+    def skus(self, id=None, **kwargs):
         if id:
-            return ProductSkus.get(self.id, id, connection=self._connection)
+            return ProductSkus.get(self.id, id, connection=self._connection, **kwargs)
         else:
-            return ProductSkus.all(self.id, connection=self._connection)
+            return ProductSkus.all(self.id, connection=self._connection, **kwargs)
+
+    def variants(self, id=None, **kwargs):
+        if id:
+            return ProductVariants.get(self.id, id, connection=self._connection, **kwargs)
+        else:
+            return ProductVariants.all(self.id, connection=self._connection, **kwargs)
 
     def videos(self, id=None):
         if id:
@@ -99,7 +105,9 @@ class ProductImages(ListableApiSubResource, CreateableApiSubResource,
     count_resource = 'products/images'
 
 
-class ProductOptions(ListableApiSubResource):
+class ProductOptions(ListableApiSubResource, CreateableApiSubResource,
+                     UpdateableApiSubResource, DeleteableApiSubResource,
+                     CollectionDeleteableApiSubResource, CountableApiSubResource):
     resource_name = 'options'
     parent_resource = 'products'
     parent_key = 'product_id'
@@ -130,6 +138,15 @@ class ProductSkus(ListableApiSubResource, CreateableApiSubResource,
     parent_resource = 'products'
     parent_key = 'product_id'
     count_resource = 'products/skus'
+
+
+class ProductVariants(ListableApiSubResource, CreateableApiSubResource,
+                      UpdateableApiSubResource, DeleteableApiSubResource,
+                      CollectionDeleteableApiSubResource, CountableApiSubResource):
+    resource_name = 'variants'
+    parent_resource = 'products'
+    parent_key = 'product_id'
+    count_resource = 'products/variants'
 
 
 class ProductVideos(ListableApiSubResource, CountableApiSubResource, 

--- a/bigcommerce/resources/variants.py
+++ b/bigcommerce/resources/variants.py
@@ -1,0 +1,10 @@
+from .base import *
+
+
+class Variants(ListableApiResource, CreateableApiSubResource,
+               UpdateableApiSubResource, DeleteableApiSubResource,
+               CollectionDeleteableApiSubResource, CountableApiSubResource):
+    resource_name = 'variants'
+    parent_resource = 'products'
+    parent_key = 'product_id'
+    count_resource = 'products/variants'


### PR DESCRIPTION
#### What?

Added `autoretry` option for 429 api rate limit (sleep and  retry call)

#### Tickets / Documentation

fixes https://github.com/bigcommerce/bigcommerce-api-python/issues/88

The client for oauth integrations should limit itself after any request (if `rate_limiting_management options` specified) but sometimes it doesn't work, so I added this `autoretry`
