### PR TITLE
Bump dependencies and Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Pipfile
 Pipfile.lock
 
 *.egg-info*
+venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.6"
+  - "3.8"
+  - "3.9"
 script: nosetests -a '!broken'

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Bigcommerce API Python Client
 Wrapper over the ``requests`` library for communicating with the Bigcommerce v2 API.
 
 Install with ``pip install bigcommerce`` or ``easy_install bigcommerce``. Tested with
-python 2.7.7+ and 3.4, and only requires ``requests`` and ``pyjwt``.
+python 3.8, and only requires ``requests`` and ``pyjwt``.
 
 Usage
 -----

--- a/bigcommerce/customer_login_token.py
+++ b/bigcommerce/customer_login_token.py
@@ -40,10 +40,8 @@ class CustomerLoginTokens(object):
 
         if request_ip:
             payload['request_ip'] = request_ip
-        
-        token = jwt.encode(payload, client_secret, algorithm='HS256')
-        
-        return token.decode('utf-8')
+
+        return jwt.encode(payload, client_secret, algorithm='HS256')
 
     @classmethod
     def create_url(cls, client, id, redirect_url=None, request_ip=None, use_bc_time=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-PyYAML==5.1
+PyYAML==5.4.1
 cov-core==1.7
 coverage==3.7.1
 mock==1.0.1
 nose==1.3.0
 nose-cov==1.6
-requests==2.20.0
-pyjwt==1.4.0
+requests==2.25.1
+pyjwt==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-VERSION = '0.20.1'
+VERSION = '0.21.0'
 
 setup(
     name = 'bigcommerce',
     version = VERSION,
 
     packages = find_packages(),
-    install_requires = ['requests>=2.1.0', 'pyjwt>=1.4.0'],
+    install_requires = ['requests>=2.25.1', 'pyjwt>=2.0.1'],
     
     
     url = 'https://github.com/bigcommerce/bigcommerce-api-python',
@@ -34,9 +34,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.9'
     ],
 )


### PR DESCRIPTION
#### What?

Bump dependencies due to security notices, remove python2 which has been deprecated for over a year.

Use newer python versions for tests.

Fix an issue with JWT library which was breaking customer login token on python 3.x.
