### PR TITLE
Fixed issue with the `verify_iss` argument passed to jwt.decode().

### DIFF
--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -239,7 +239,9 @@ class OAuthConnection(Connection):
                           client_secret,
                           algorithms=["HS256"],
                           audience=client_id,
-                          verify_iss=False)
+                          options={
+                            'verify_iss': False
+                          })
 
     def fetch_token(self, client_secret, code, context, scope, redirect_uri,
                     token_url='https://login.bigcommerce.com/oauth2/token'):


### PR DESCRIPTION
#### What?

Error Occurred with jwt.decode() option `verify_iss=False` passed when calling the `load` handler for this specific line https://github.com/bigcommerce/hello-world-app-python-flask/blob/master/app.py#L198
```
JWT verification failed: decode() got an unexpected keyword argument 'verify_iss'

Payload verification failed!
```

#### Tickets / Documentation

It appears that PyJWT Decode doesn't accept `verify_iss` as a argument. 
https://github.com/jpadilla/pyjwt/blob/2.2.0/jwt/api_jwt.py#L113-L120

Looking further into that `decode()` it looks like the `options` argument is where the `verify_iss` is added.
https://github.com/jpadilla/pyjwt/blob/2.2.0/jwt/api_jwt.py#L85


