### PR TITLE
Fix issue when decoding the Current Customer JWT Payload

### DIFF
--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -222,7 +222,7 @@ class OAuthConnection(Connection):
 
         Uses constant-time str comparison to prevent vulnerability to timing attacks.
         """
-        encoded_json, encoded_hmac = signed_payload.split('.')
+        encoded_json, encoded_hmac, __ = signed_payload.split('.')
         dc_json = base64.b64decode(encoded_json)
         signature = base64.b64decode(encoded_hmac)
         expected_sig = hmac.new(client_secret.encode(), base64.b64decode(encoded_json), hashlib.sha256).hexdigest()
@@ -237,7 +237,7 @@ class OAuthConnection(Connection):
         """
         return jwt.decode(signed_payload,
                           client_secret,
-                          algorithms=["HS256"],
+                          algorithms=["HS256", "HS512"],
                           audience=client_id,
                           options={
                             'verify_iss': False

--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -222,7 +222,7 @@ class OAuthConnection(Connection):
 
         Uses constant-time str comparison to prevent vulnerability to timing attacks.
         """
-        encoded_json, encoded_hmac, __ = signed_payload.split('.')
+        encoded_json, encoded_hmac = signed_payload.split('.')
         dc_json = base64.b64decode(encoded_json)
         signature = base64.b64decode(encoded_hmac)
         expected_sig = hmac.new(client_secret.encode(), base64.b64decode(encoded_json), hashlib.sha256).hexdigest()


### PR DESCRIPTION
The token created from this endpoint uses algorithm "HS512". Added this algorithm to the array.
https://developer.bigcommerce.com/api-docs/storefront/current-customer-api

Also noticed that when using `verify_payload` it gave an error since there were three values returned. Put a `__` to handle the last value returned.