### PR TITLE
Change CD GH action to be trigged on release instead of push, and bump version/release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
 on:
-  push:
-    branches: [master, main]
+  release:
+    types: [released]
 
 jobs:
   build-n-publish:
@@ -28,7 +28,6 @@ jobs:
           --wheel
           --outdir dist/
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-VERSION = '0.23.1'
+VERSION = '0.23.2'
 
 setup(
     name='bigcommerce',


### PR DESCRIPTION
This push strategy doesn't work with the sequence of how we tag releases, so I've changed the trigger to be on release.